### PR TITLE
database: change RAM power property from INTEGER to DOUBLE

### DIFF
--- a/server/src/data/migrations/20200804105739-create-ram.js
+++ b/server/src/data/migrations/20200804105739-create-ram.js
@@ -22,7 +22,7 @@ module.exports = {
       },
       power: {
         allowNull: false,
-        type: Sequelize.INTEGER,
+        type: Sequelize.DOUBLE,
       },
       typeId: {
         type: Sequelize.INTEGER,


### PR DESCRIPTION
RAM power property can be double.
![image](https://user-images.githubusercontent.com/40521835/89520546-ae9a0200-d7e6-11ea-8aed-0800d67648a3.png)
