### PR TITLE
Edit length of user password for contain hashed passwords

### DIFF
--- a/server/src/data/migrations/20200808235716-modify-length-of-passwor-in-user-table.js
+++ b/server/src/data/migrations/20200808235716-modify-length-of-passwor-in-user-table.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('users', 'password', {
+      type: Sequelize.STRING(60),
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('users', 'password', {
+      type: Sequelize.STRING(50),
+    });
+  },
+};


### PR DESCRIPTION
Based on the bcrypt documentation, the hash length is 60 characters. Therefore, the length of the password field in the users table has been changed.