### PR TITLE
Fix/fix-getAll-in-repositories

### DIFF
--- a/server/src/data/repositories/gpu.repository.ts
+++ b/server/src/data/repositories/gpu.repository.ts
@@ -13,7 +13,7 @@ export class GpuRepository extends BaseRepository<GpuModel> {
 
   async getAllGpus(): Promise<GpuModel[]> {
     const gpus = await this.getAll();
-    return gpus;
+    return gpus.data;
   }
 
   async createGpu(inputGpu: GpuDataAttributes): Promise<GpuModel> {

--- a/server/src/data/repositories/powerSupply.repository.ts
+++ b/server/src/data/repositories/powerSupply.repository.ts
@@ -13,7 +13,7 @@ export class PowerSupplyRepository extends BaseRepository<PowerSupplyModel> {
 
   async getAllPowerSupplies(): Promise<PowerSupplyModel[]> {
     const powerSupplies = await this.getAll();
-    return powerSupplies;
+    return powerSupplies.data;
   }
 
   async createPowerSupply(inputPowerSupply: PowerSupplyDataAttributes): Promise<PowerSupplyModel> {

--- a/server/src/data/repositories/ramType.repository.ts
+++ b/server/src/data/repositories/ramType.repository.ts
@@ -12,8 +12,8 @@ export class RamTypeRepository extends BaseRepository<RamTypeModel> {
   }
 
   async getAllRamTypes(): Promise<RamTypeModel[]> {
-    const ramTypes = await this.model.findAll();
-    return ramTypes;
+    const ramTypes = await this.getAll();
+    return ramTypes.data;
   }
 
   async createRamType(inputRamType: RamTypeDataAttributes): Promise<RamTypeModel> {

--- a/server/src/data/repositories/socket.repository.ts
+++ b/server/src/data/repositories/socket.repository.ts
@@ -13,7 +13,7 @@ export class SocketRepository extends BaseRepository<SocketModel> {
 
   async getAllSockets(): Promise<SocketModel[]> {
     const sockets = await this.getAll();
-    return sockets;
+    return sockets.data;
   }
 
   async createSocket(inputSocket: SocketDataAttributes): Promise<SocketModel> {


### PR DESCRIPTION
this.getAll() now returns object with meta and data properties. So, if we dont need meta, we return only array of items.